### PR TITLE
Release 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,38 @@ After the agent is bootstrapped and starts accepting spans from Envoy, the resul
 ## Setup an Application Perspective for the Demo
 
 The simplest way is just to assign to the agent a unique zone (the `docker-compose.yml` file comes with the pre-defined `envoy-tracing-demo`), and simply create the application to contain all calls with the `agent.zone` tag to have the value `envoy-tracing-demo`.
+
+## Released Binaries
+
+**Link**: https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/<br/>
+**Credentials**: `_:${agent_key}`
+
+Only `linux-amd64-libinstana_sensor.so` is required on Linux distributions using glibc. For musl libc, there is the module `linux-amd64-musl-libinstana_sensor.so`.
+
+Since version 0.6.0, there are additional modules for Nginx tracing as Nginx does not come with OpenTracing support by default. Those can be ignored for Envoy tracing.
+
+## Release History
+
+### 0.7.0 (2020-01-02)
+
+   * logging `libinstana_sensor` version upon module load
+      * information gathering for better support
+   * added timestamps and prefix "[lis]" to log messages for better debugging
+   * added pid to log messages
+   * enforcing IPv4 in agent host name resolution
+      * avoiding failure due to IPv6 address for same host name
+   * implemented a new discovery request format
+      * requiring the C++ sensor 1.1.0 agent part for faster agent connection
+   * reworked the agent connection/discovery to quickly connect
+      * if no agent host is configured, then the gateway is checked first
+   * only logging an error if connections to all agent host candidates fail
+      * converted misleading error message upon failure of first candidate
+   * increased span flushing interval from 5s to 1s
+
+### 0.6.0 (2019-09-06)
+
+   * no changes relevant to Envoy tracing
+
+### 0.5.4 (2019-03-20)
+
+   * initial public release

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,9 +61,9 @@ services:
         aliases:
           - instana-agent
     environment:
-      - INSTANA_AGENT_ENDPOINT=${agent_endpoint:?No agent endpoint provided}
+      - INSTANA_AGENT_ENDPOINT=${agent_endpoint:-saas-us-west-2.instana.io}
       - INSTANA_AGENT_ENDPOINT_PORT=${agent_endpoint_port:-443}
-      - INSTANA_AGENT_KEY=${agent_key:?No agent key provided}
+      - INSTANA_AGENT_KEY=${agent_key}
       - INSTANA_AGENT_ZONE=${agent_zone:-envoy-tracing-demo}
     expose:
       - "42699"

--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -15,8 +15,6 @@ ENV INSTANA_AGENT_KEY=${agent_key}
 RUN sensor_version=$(lynx -auth _:${INSTANA_AGENT_KEY} -dump -listonly https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/ | grep -o 'https:.*/[0-9]\+\.[0-9]\+\.[0-9]\+/' | rev | cut -d '/' -f 2 | rev | sort -V | tail -n1); \
     curl --user _:${INSTANA_AGENT_KEY} --silent --output /usr/local/lib/libinstana_sensor.so https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/${sensor_version}/linux-amd64-libinstana_sensor.so
 
-RUN chmod 777 /usr/local/lib/libinstana_sensor.so 
-
 ADD ./start-gateway.sh /usr/local/bin/start-gateway.sh
 RUN chmod u+x /usr/local/bin/start-gateway.sh
 


### PR DESCRIPTION
    docker-compose: Fix env variable syntax
    
    The ":?" syntax does not work with all Linux distributions. E.g.
    it is unknown on openSUSE Leap 15.1. So avoid it.
--------------
    envoy: Drop chmod for libinstana_sensor
    
    It is a security risk to make the library executable. It is loaded
    by dlopen() from envoy and only needs to be readable this way.
------------
    README: Add released binaries and release history
    
    This repository is used to inform customers about progress with
    the Envoy tracing. So they should be informed about changes in how
    we provide the released binaries and what changed between releases.
