### PR TITLE
Update Envoy to version v1.21 and various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,67 +2,85 @@
 
 This repository contains a technology preview for Instana's [Envoy](https://www.envoyproxy.io/) tracing functionality.
 
-## Disclaimer
-
-*Instana Envoy tracing is currently a technology preview.*
-
-We reserve ourselves the right to make it better and easier before releasing the functionality for General Availability.
-
 ## Supported Versions
 
-The distributed tracing is compatible with Envoy Proxy versions 1.12 and 1.13. It is currently incompatible with versions 1.14 and above.
+The distributed tracing is compatible with Envoy Proxy versions 1.15 and above.
 
 ## Prerequisites
 
-A `docker-compose` installation running on your machine. This demo has been created and tested on Mac OS X with `docker-compose` and `docker-machine`.
+A `docker-compose` installation running on your machine. This demo has been created and tested on Mac OS 
+and RHEL with `docker-compose` and `docker-machine`.
 
 ## Configure
 
-Create a `.env` file in the root of the checked-out version of this repository and enter the following text, with the values adjusted as necessary:
+Create a `.env` file in the root of the checked-out version of this repository and enter the following content. 
+The values need to be adjusted to your environment.
 
 ```text
-agent_key=<TODO FILL UP>
+agent_key=<agent secret key>
+agent_zone=<name of the zone for the agent; default: envoy-tracing-demo>
 agent_endpoint=<local ip or remote host; e.g., saas-us-west-2.instana.io>
 agent_endpoint_port=<443 already set as default; or 4443 for local>
-agent_zone=<name of the zone for the agent; default: envoy-tracing-demo>
 ```
 
-## Build
+In most scenarios only the field `agent_key` and `agent_endpoint` are required.  
+
+## Build & Launch
 
 ```bash
 docker-compose build
-```
-
-## Launch
-
-```bash
 docker-compose up
 ```
 
-This will build and launch
-
+This will build and launch the following components:
 - `client-app` service, a simple Spring Boot application that issues a request every second to the ...
 - `envoy` service, which routes all incoming requests to the ...
 - `server-app` service, a simple Spring Boot application that returns `200` to any HTTP request.
 
-After the agent is bootstrapped and starts accepting spans from Envoy, the resulting traces in the Analyze view will look like the following:
+After the agent is bootstrapped and starts accepting spans from Envoy, the resulting traces in the Analyze view will 
+look like this:
 
 ![Demo traces in the Analyze view](images/trace-view.png)
 
-## Setup an Application Perspective for the Demo
+## Create an Application Perspective for the Demo
 
-The simplest way is just to assign to the agent a unique zone (the `docker-compose.yml` file comes with the pre-defined `envoy-tracing-demo`), and simply create the application to contain all calls with the `agent.zone` tag to have the value `envoy-tracing-demo`.
+To view all calls in its own application, create a new *Application Perspective* from the *Application* menu
+with a filter for the agent zone (`agent.zone`). The filter value must be the value of the `agent_zone` from
+the `.env` file. If `agent_zone` is not set, it defaults to `envoy-tracing-demo`.
 
 ## Released Binaries
 
 **Link**: https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/<br/>
 **Credentials**: `_:${agent_key}`
 
-Only `linux-amd64-libinstana_sensor.so` is required on Linux distributions using glibc. For musl libc, there is the module `linux-amd64-musl-libinstana_sensor.so`.
-
-Since version 0.6.0, there are additional modules for NGINX tracing as NGINX does not come with OpenTracing support by default. Those can be ignored for Envoy tracing.
+Only `linux-amd64-libcxx-libinstana_sensor.so` is required.
 
 ## Release History
+
+### 1.5.0 (2022-02-17)
+
+   * add support for Envoy 1.15 and greater
+
+### 1.4.0 (2022-02-14)
+
+   * drop support for Envoy 1.13 and below in new releases
+
+### 1.3.0 (2021-12-09)
+
+   * dropped initial wait time of 10s before connecting to the Instana agent
+   * now dropping all spans if the agent connection is not established
+       * avoiding too delayed spans
+       * avoiding using wrongs secrets configuration
+   * reduced the interval to poll the answering Instana agent from 30s to 5s
+       * faster agent connection
+
+### 1.2.3 (2021-11-11)
+
+   * now storing trace and span IDs as hex strings internally resulting in better debug output
+
+### 1.2.0 (2021-10-14)
+
+   * fixed handling of requests where `X-INSTANA-L` is set to zero
 
 ### 1.1.0 (2020-07-31)
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Only `linux-amd64-libcxx-libinstana_sensor.so` is required.
 
 ### 1.5.0 (2022-02-17)
 
-   * add support for Envoy 1.15 and greater
+   * added support for Envoy 1.15 and greater
 
-### 1.4.0 (2022-02-14)
+### 1.4.0 (2022-02-04)
 
-   * drop support for Envoy 1.13 and below in new releases
+   * dropped support for Envoy 1.13 and below in new releases
 
 ### 1.3.0 (2021-12-09)
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,6 @@ agent_zone=<name of the zone for the agent; default: envoy-tracing-demo>
 ## Build
 
 ```bash
-pushd client-app
-./mvnw clean package
-popd
-
-pushd server-app
-./mvnw clean package
-popd
-
 docker-compose build
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The values need to be adjusted to your environment.
 
 ```text
 agent_key=<agent secret key>
+download_key=<download secret key>
 agent_zone=<name of the zone for the agent; default: envoy-tracing-demo>
 agent_endpoint=<local ip or remote host; e.g., saas-us-west-2.instana.io>
 agent_endpoint_port=<443 already set as default; or 4443 for local>

--- a/client-app/.dockerignore
+++ b/client-app/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+
+.dockerignore
+Dockerfile
+
+mvnw.cmd
+.mvn/wrapper/maven-wrapper.jar

--- a/client-app/Dockerfile
+++ b/client-app/Dockerfile
@@ -1,5 +1,19 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:11-jdk-slim AS evnoy-tracing-client-app-build
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y && apt-get install -y --no-install-recommends --no-install-suggests \
+    curl \
+    ca-certificates
+
+WORKDIR /opt/client-app/
+COPY . .
+RUN ./mvnw clean package
+
+FROM openjdk:11-jre-slim
+
 VOLUME /tmp
+WORKDIR /opt/client-app/
 ARG JAR_FILE=target/client-app-1.0.0.RELEASE.jar
-ADD ${JAR_FILE} app.jar
+COPY --from=evnoy-tracing-client-app-build /opt/client-app/${JAR_FILE} ./app.jar
+
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/client-app/Dockerfile
+++ b/client-app/Dockerfile
@@ -1,12 +1,14 @@
 FROM openjdk:11-jdk-slim AS evnoy-tracing-client-app-build
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -y && apt-get install -y --no-install-recommends --no-install-suggests \
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends --no-install-suggests \
     curl \
-    ca-certificates
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/client-app/
-COPY . .
+COPY ./ ./
 RUN ./mvnw clean package
 
 FROM openjdk:11-jre-slim
@@ -16,4 +18,4 @@ WORKDIR /opt/client-app/
 ARG JAR_FILE=target/client-app-1.0.0.RELEASE.jar
 COPY --from=evnoy-tracing-client-app-build /opt/client-app/${JAR_FILE} ./app.jar
 
-ENTRYPOINT ["java","-jar","app.jar"]
+CMD ["java","-jar","app.jar"]

--- a/client-app/Dockerfile
+++ b/client-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim AS evnoy-tracing-client-app-build
+FROM openjdk:11-jdk-slim AS envoy-tracing-client-app-build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
@@ -16,6 +16,6 @@ FROM openjdk:11-jre-slim
 VOLUME /tmp
 WORKDIR /opt/client-app/
 ARG JAR_FILE=target/client-app-1.0.0.RELEASE.jar
-COPY --from=evnoy-tracing-client-app-build /opt/client-app/${JAR_FILE} ./app.jar
+COPY --from=envoy-tracing-client-app-build /opt/client-app/${JAR_FILE} ./app.jar
 
 CMD ["java","-jar","app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     networks:
       envoymesh:
         aliases:
-          - service
+          - server-app
     environment:
       - INSTANA_DEV=1
       - INSTANA_AGENT_HOST=instana-agent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,9 @@ services:
       - INSTANA_DEV=1
       - INSTANA_AGENT_HOST=instana-agent
       - INSTANA_AGENT_PORT=42699
-    expose:
-      - "8000"
-      - "8001"
+    ports:
+      - "8000:8000"
+      - "8001:8001"
 
   server-app:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - INSTANA_AGENT_ENDPOINT=${agent_endpoint:-saas-us-west-2.instana.io}
       - INSTANA_AGENT_ENDPOINT_PORT=${agent_endpoint_port:-443}
       - INSTANA_AGENT_KEY=${agent_key}
+      - INSTANA_DOWNLOAD_KEY=${download_key}
       - INSTANA_AGENT_ZONE=${agent_zone:-envoy-tracing-demo}
     expose:
       - "42699"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-# Original from envoyproject/envoy:examples/front-proxy/docker-compose.yml
-# Modified by Instana:
-# - use instana-opentracing dockerfiles
 version: '3'
 services:
 
@@ -18,6 +15,7 @@ services:
       context: ./envoy
       args:
         agent_key: ${agent_key}
+        download_key: ${download_key}
     volumes:
       - ./envoy/envoy-gateway.yaml:/etc/envoy-gateway.yaml
     networks:
@@ -35,6 +33,9 @@ services:
   server-app:
     build:
       context: ./server-app
+      args:
+        agent_key: ${agent_key}
+        download_key: ${download_key}
     networks:
       envoymesh:
         aliases:

--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -1,21 +1,28 @@
 # Original from envoyproject/envoy:examples/front-proxy/Dockerfile-frontenvoy
 FROM envoyproxy/envoy:v1.21-latest
 
-RUN set -x \
-  && apt-get update \
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
   && apt-get install --no-install-recommends --no-install-suggests -y \
-              curl apt-transport-https iproute2 \
-  && apt-get install --no-install-recommends --no-install-suggests -y lynx
+    wget \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
-ARG agent_key
-
-ENV INSTANA_AGENT_KEY=${agent_key}
+WORKDIR /opt/envoy/
 
 # download latest libinstana_sensor from artifactory
-RUN sensor_version=$(lynx -auth _:${INSTANA_AGENT_KEY} -dump -listonly https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/ | grep -o 'https:.*/[0-9]\+\.[0-9]\+\.[0-9]\+/' | rev | cut -d '/' -f 2 | rev | sort -V | tail -n1); \
-    curl --user _:${INSTANA_AGENT_KEY} --silent --output /usr/local/lib/libinstana_sensor.so https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/${sensor_version}/linux-amd64-libinstana_sensor.so
+ARG agent_key
+ARG download_key
+ENV ARTI_PATH='https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/' \
+    INSTANA_DOWNLOAD_KEY=${download_key} \
+    INSTANA_AGENT_KEY=${agent_key}
 
-ADD ./start-gateway.sh /usr/local/bin/start-gateway.sh
-RUN chmod u+x /usr/local/bin/start-gateway.sh
+RUN access_key=$([ ! -z "${INSTANA_DOWNLOAD_KEY}" ] && echo "${INSTANA_DOWNLOAD_KEY}" || echo "${INSTANA_AGENT_KEY}") \
+    && wget --user _ --password ${access_key} --output-document=./list.html ${ARTI_PATH} \
+    && sensor_version=$(grep -o "href=\"[0-9]\+\.[0-9]\+\.[0-9]\+/\"" ./list.html | tail -n1 | cut -d'"' -f2) \
+    && echo "Using sensor version ${sensor_version}" \
+    && wget --user _ --password ${access_key} --output-document=./libcxx-libinstana_sensor.so ${ARTI_PATH}${sensor_version}linux-amd64-libcxx-libinstana_sensor.so
 
-ENTRYPOINT /usr/local/bin/start-gateway.sh
+COPY ./start-gateway.sh ./envoy-gateway.yaml ./
+
+CMD ["./start-gateway.sh"]

--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -1,5 +1,5 @@
 # Original from envoyproject/envoy:examples/front-proxy/Dockerfile-frontenvoy
-FROM envoyproxy/envoy:ff857396dc6e8c9a94c547bf080ecf6eaa38e333
+FROM envoyproxy/envoy:v1.21-latest
 
 RUN set -x \
   && apt-get update \
@@ -11,7 +11,7 @@ ARG agent_key
 
 ENV INSTANA_AGENT_KEY=${agent_key}
 
-# Download extension from Artifactory
+# download latest libinstana_sensor from artifactory
 RUN sensor_version=$(lynx -auth _:${INSTANA_AGENT_KEY} -dump -listonly https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/ | grep -o 'https:.*/[0-9]\+\.[0-9]\+\.[0-9]\+/' | rev | cut -d '/' -f 2 | rev | sort -V | tail -n1); \
     curl --user _:${INSTANA_AGENT_KEY} --silent --output /usr/local/lib/libinstana_sensor.so https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/${sensor_version}/linux-amd64-libinstana_sensor.so
 

--- a/envoy/envoy-gateway.yaml
+++ b/envoy/envoy-gateway.yaml
@@ -1,6 +1,5 @@
-# Original from envoyproject/envoy:examples/front-proxy/envoy-gateway.yaml
-# Modified by Instana:
-# - add tracing configuration for libinstana_sensor.so
+# Based on: https://github.com/envoyproxy/envoy/tree/main/examples/front-proxy
+# Modification by Instana: add tracing configuration for libinstana_sensor.so
 static_resources:
 
   listeners:
@@ -33,7 +32,7 @@ static_resources:
               name: envoy.tracers.dynamic_ot
               typed_config:
                 "@type": type.googleapis.com/envoy.config.trace.v3.DynamicOtConfig
-                library: /usr/local/lib/libinstana_sensor.so
+                library: /opt/envoy/libcxx-libinstana_sensor.so
                 config:
                   service: envoy-front-proxy
 

--- a/envoy/start-gateway.sh
+++ b/envoy/start-gateway.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-/usr/local/bin/envoy -c /etc/envoy-gateway.yaml --service-cluster envoy-gateway
+/usr/local/bin/envoy -c /opt/envoy/envoy-gateway.yaml --service-cluster envoy-gateway

--- a/server-app/.dockerignore
+++ b/server-app/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+
+.dockerignore
+Dockerfile
+
+mvnw.cmd
+.mvn/wrapper/maven-wrapper.jar

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -1,19 +1,40 @@
 FROM openjdk:11-jdk-slim AS evnoy-tracing-server-app-build
 
+ARG agent_key
+ENV INSTANA_AGENT_KEY=${agent_key}
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y --no-install-recommends --no-install-suggests \
     curl \
+    lynx \
     ca-certificates
 
 WORKDIR /opt/server-app/
+
+# download latest libinstana_sensor from artifactory
+RUN sensor_version=$(lynx -auth _:${INSTANA_AGENT_KEY} -dump -listonly https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/ | grep -o 'https:.*/[0-9]\+\.[0-9]\+\.[0-9]\+/' | rev | cut -d '/' -f 2 | rev | sort -V | tail -n1) \
+    && curl --user _:${INSTANA_AGENT_KEY} --silent --output ./libinstana_sensor.so https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/${sensor_version}/linux-amd64-libinstana_sensor.so
+
 COPY . .
 RUN ./mvnw clean package
 
-FROM openjdk:11-jre-slim
+FROM envoyproxy/envoy:v1.21-latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+      openjdk-11-jre \
+      tzdata \
+      ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 VOLUME /tmp
 WORKDIR /opt/server-app/
-ARG JAR_FILE=target/server-app-1.0.0.RELEASE.jar
-COPY --from=evnoy-tracing-server-app-build /opt/server-app/${JAR_FILE} ./app.jar
 
-ENTRYPOINT ["java","-jar","app.jar"]
+ARG jar_file=target/server-app-1.0.0.RELEASE.jar
+COPY --from=evnoy-tracing-server-app-build /opt/server-app/${jar_file} ./app.jar
+COPY --from=evnoy-tracing-server-app-build /opt/server-app/libinstana_sensor.so ./
+
+COPY start-server-app.sh envoy-server-app.yaml ./
+ENTRYPOINT ["./start-server-app.sh"]
+
+CMD ["java","-jar","app.jar"]

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -1,5 +1,19 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:11-jdk-slim AS evnoy-tracing-server-app-build
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y && apt-get install -y --no-install-recommends --no-install-suggests \
+    curl \
+    ca-certificates
+
+WORKDIR /opt/server-app/
+COPY . .
+RUN ./mvnw clean package
+
+FROM openjdk:11-jre-slim
+
 VOLUME /tmp
+WORKDIR /opt/server-app/
 ARG JAR_FILE=target/server-app-1.0.0.RELEASE.jar
-ADD ${JAR_FILE} app.jar
+COPY --from=evnoy-tracing-server-app-build /opt/server-app/${JAR_FILE} ./app.jar
+
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim AS evnoy-tracing-server-app-build
+FROM openjdk:11-jdk-slim AS envoy-tracing-server-app-build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
@@ -39,8 +39,8 @@ VOLUME /tmp
 WORKDIR /opt/server-app/
 
 ARG jar_file=target/server-app-1.0.0.RELEASE.jar
-COPY --from=evnoy-tracing-server-app-build /opt/server-app/${jar_file} ./app.jar
-COPY --from=evnoy-tracing-server-app-build /opt/server-app/libcxx-libinstana_sensor.so ./
+COPY --from=envoy-tracing-server-app-build /opt/server-app/${jar_file} ./app.jar
+COPY --from=envoy-tracing-server-app-build /opt/server-app/libcxx-libinstana_sensor.so ./
 
 COPY ./start-server-app.sh ./envoy-server-app.yaml ./
 ENTRYPOINT ["./start-server-app.sh"]

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -1,18 +1,26 @@
 FROM openjdk:11-jdk-slim AS evnoy-tracing-server-app-build
 
-ARG agent_key
-ENV INSTANA_AGENT_KEY=${agent_key}
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -y && apt-get install -y --no-install-recommends --no-install-suggests \
-    curl \
-    lynx \
-    ca-certificates
+RUN apt-get update \
+  && apt-get install --no-install-recommends --no-install-suggests -y \
+    wget \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/server-app/
 
 # download latest libinstana_sensor from artifactory
-RUN sensor_version=$(lynx -auth _:${INSTANA_AGENT_KEY} -dump -listonly https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/ | grep -o 'https:.*/[0-9]\+\.[0-9]\+\.[0-9]\+/' | rev | cut -d '/' -f 2 | rev | sort -V | tail -n1) \
-    && curl --user _:${INSTANA_AGENT_KEY} --silent --output ./libinstana_sensor.so https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/${sensor_version}/linux-amd64-libinstana_sensor.so
+ARG agent_key
+ARG download_key
+ENV ARTI_PATH='https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/' \
+    INSTANA_DOWNLOAD_KEY=${download_key} \
+    INSTANA_AGENT_KEY=${agent_key}
+
+RUN access_key=$([ ! -z "${INSTANA_DOWNLOAD_KEY}" ] && echo "${INSTANA_DOWNLOAD_KEY}" || echo "${INSTANA_AGENT_KEY}") \
+    && wget --user _ --password ${access_key} --output-document=./list.html ${ARTI_PATH} \
+    && sensor_version=$(grep -o "href=\"[0-9]\+\.[0-9]\+\.[0-9]\+/\"" ./list.html | tail -n1 | cut -d'"' -f2) \
+    && echo "Using sensor version ${sensor_version}" \
+    && wget --user _ --password ${access_key} --output-document=./libcxx-libinstana_sensor.so ${ARTI_PATH}${sensor_version}linux-amd64-libcxx-libinstana_sensor.so
 
 COPY . .
 RUN ./mvnw clean package
@@ -32,9 +40,9 @@ WORKDIR /opt/server-app/
 
 ARG jar_file=target/server-app-1.0.0.RELEASE.jar
 COPY --from=evnoy-tracing-server-app-build /opt/server-app/${jar_file} ./app.jar
-COPY --from=evnoy-tracing-server-app-build /opt/server-app/libinstana_sensor.so ./
+COPY --from=evnoy-tracing-server-app-build /opt/server-app/libcxx-libinstana_sensor.so ./
 
-COPY start-server-app.sh envoy-server-app.yaml ./
+COPY ./start-server-app.sh ./envoy-server-app.yaml ./
 ENTRYPOINT ["./start-server-app.sh"]
 
 CMD ["java","-jar","app.jar"]

--- a/server-app/envoy-server-app.yaml
+++ b/server-app/envoy-server-app.yaml
@@ -1,6 +1,3 @@
-# Original from envoyproject/envoy:examples/front-proxy/envoy-gateway.yaml
-# Modified by Instana:
-# - add tracing configuration for libinstana_sensor.so
 static_resources:
 
   listeners:
@@ -25,7 +22,7 @@ static_resources:
               - match:
                   prefix: ""
                 route:
-                  cluster: server_app
+                  cluster: local_server_app
           http_filters:
           - name: envoy.filters.http.router
           tracing:
@@ -33,27 +30,27 @@ static_resources:
               name: envoy.tracers.dynamic_ot
               typed_config:
                 "@type": type.googleapis.com/envoy.config.trace.v3.DynamicOtConfig
-                library: /usr/local/lib/libinstana_sensor.so
+                library: /opt/server-app/libinstana_sensor.so
                 config:
-                  service: envoy-front-proxy
+                  service: envoy-server-app
 
   clusters:
-  - name: server_app
+  - name: local_server_app
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
-      cluster_name: server_app
+      cluster_name: local_server
       endpoints:
       - lb_endpoints:
         - endpoint:
             address:
               socket_address:
-                address: server-app
-                port_value: 8000
+                address: 127.0.0.1
+                port_value: 8080
 
 admin:
   access_log_path: /dev/null
   address:
     socket_address:
       address: 0.0.0.0
-      port_value: 8001
+      port_value: 8081

--- a/server-app/envoy-server-app.yaml
+++ b/server-app/envoy-server-app.yaml
@@ -1,3 +1,5 @@
+# Based on: https://github.com/envoyproxy/envoy/tree/main/examples/front-proxy
+# Modification by Instana: add tracing configuration for libinstana_sensor.so
 static_resources:
 
   listeners:
@@ -30,7 +32,7 @@ static_resources:
               name: envoy.tracers.dynamic_ot
               typed_config:
                 "@type": type.googleapis.com/envoy.config.trace.v3.DynamicOtConfig
-                library: /opt/server-app/libinstana_sensor.so
+                library: /opt/server-app/libcxx-libinstana_sensor.so
                 config:
                   service: envoy-server-app
 

--- a/server-app/start-server-app.sh
+++ b/server-app/start-server-app.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set +x
+
+(exec "$@" &)
+/usr/local/bin/envoy -c envoy-server-app.yaml --service-cluster "server_app"


### PR DESCRIPTION
Update Envoy to version v1.21

Improvements:
* Add sidecar to server-app
* Use multi-stage builds to facilitate a single build command
* Make front-proxy accessible to host
* Update the documentation and also removed the note about the Envoy beta.

*Note: this pr should be merged **after** the sensor for Envoy is released and the demo was tested with it.*
*The downloaded binary must also be adjusted to the one built with clang before this gets merged.*