### PR TITLE
docker-compose: Pull the Instana agent from icr.io

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,20 +49,21 @@ services:
       - "8080"
 
   agent:
-    image: instana/agent
+    image: icr.io/instana/agent
     pid: "host"
     privileged: true
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /dev:/dev
-      - /sys:/sys
-      - /var/log:/var/log
+      - /var/run:/var/run
+      - /run:/run
+      - /dev:/dev:ro
+      - /sys:/sys:ro
+      - /var/log:/var/log:ro
     networks:
       envoymesh:
         aliases:
           - instana-agent
     environment:
-      - INSTANA_AGENT_ENDPOINT=${agent_endpoint:-saas-us-west-2.instana.io}
+      - INSTANA_AGENT_ENDPOINT=${agent_endpoint:-ingress-red-saas.instana.io}
       - INSTANA_AGENT_ENDPOINT_PORT=${agent_endpoint_port:-443}
       - INSTANA_AGENT_KEY=${agent_key}
       - INSTANA_DOWNLOAD_KEY=${download_key}


### PR DESCRIPTION
Due to IBM policies, the Instana agent image may not be uploaded to DockerHub anymore. The image was still cached on my machine though. But for other users `docker-compose up` results in an error when pulling the image. The Instana agent images are uploaded to icr.io now.

So update the agent image config with the information from the Instana UI "Installing Instana Agents" -> "Docker".

Reported-by: Yang Kwang Goh <gohykw@sg.ibm.com>