### PR TITLE
Update Envoy to version v1.22 and improvements

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,9 @@
+
+agent_key=TODO: Provide an agent key.
+agent_zone=<the agent's zone>
+
+# download_key=TODO: If your agent key does not have download privileges, you also need to provide a download key.
+
+agent_endpoint=<any saas.instana.rocks>
+agent_endpoint_port=443
+

--- a/.env.template
+++ b/.env.template
@@ -1,9 +1,5 @@
-
-agent_key=TODO: Provide an agent key.
-agent_zone=<the agent's zone>
-
-# download_key=TODO: If your agent key does not have download privileges, you also need to provide a download key.
-
-agent_endpoint=<any saas.instana.rocks>
+agent_key=<agent secret key>
+#download_key=<download secret key (optional agent key with download privileges)>
+agent_zone=<name of the zone for the agent; default: envoy-tracing-demo>
+agent_endpoint=<local ip or remote host; e.g. ingress-red-saas.instana.io>
 agent_endpoint_port=443
-

--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ The values need to be adjusted to your environment.
 
 ```text
 agent_key=<agent secret key>
-download_key=<download secret key>
+download_key=<download secret key (optional agent key with download privileges)>
 agent_zone=<name of the zone for the agent; default: envoy-tracing-demo>
-agent_endpoint=<local ip or remote host; e.g., saas-us-west-2.instana.io>
+agent_endpoint=<local ip or remote host; e.g. ingress-red-saas.instana.io>
 agent_endpoint_port=<443 already set as default; or 4443 for local>
 ```
 
 In most scenarios only the field `agent_key` and `agent_endpoint` are required.  
+
+A template [.env.template](.env.template) can be copied to `.env` for your convenience.
 
 ## Build & Launch
 

--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -1,5 +1,5 @@
 # Original from envoyproject/envoy:examples/front-proxy/Dockerfile-frontenvoy
-FROM envoyproxy/envoy:v1.21-latest
+FROM envoyproxy/envoy:v1.22-latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/envoy/envoy-gateway.yaml
+++ b/envoy/envoy-gateway.yaml
@@ -26,6 +26,8 @@ static_resources:
                             cluster: server_app
                 http_filters:
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                 tracing:
                   provider:
                     name: envoy.tracers.dynamic_ot

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -25,7 +25,7 @@ RUN access_key=$([ ! -z "${INSTANA_DOWNLOAD_KEY}" ] && echo "${INSTANA_DOWNLOAD_
 COPY . .
 RUN ./mvnw clean package
 
-FROM envoyproxy/envoy:v1.21-latest
+FROM envoyproxy/envoy:v1.22-latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/server-app/envoy-server-app.yaml
+++ b/server-app/envoy-server-app.yaml
@@ -26,6 +26,8 @@ static_resources:
                             cluster: local_server_app
                 http_filters:
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                 tracing:
                   provider:
                     name: envoy.tracers.dynamic_ot


### PR DESCRIPTION
Update Envoy to version v1.22, update its configuration files according to the new schema.

**Improvements:**

- add a template for environment files

**Tests**

The calls to envoy-demo are visible in this picture from Instana Pink.
Also traces for two calls to hello-world are visible (`curl -v localhost:8080/helloworld`).

![image](https://user-images.githubusercontent.com/85874226/196718886-6603c8d5-b32c-49c2-84bc-b02ff60d2535.png)
