### PR TITLE
envoy, server-app: Update to Envoy 1.27 latest

### DIFF
--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -1,5 +1,5 @@
 # Original from envoyproject/envoy:examples/front-proxy/Dockerfile-frontenvoy
-FROM envoyproxy/envoy:v1.22-latest
+FROM envoyproxy/envoy:v1.27-latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -25,7 +25,7 @@ RUN access_key=$([ ! -z "${INSTANA_DOWNLOAD_KEY}" ] && echo "${INSTANA_DOWNLOAD_
 COPY . .
 RUN ./mvnw clean package
 
-FROM envoyproxy/envoy:v1.22-latest
+FROM envoyproxy/envoy:v1.27-latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \


### PR DESCRIPTION
Confusion about supported Envoy versions arose from a customer ticket. Customers expect to get latest versions demoed.
So just bump all Envoy versions from 1.22 to 1.27.