### PR TITLE
README: Link to envoy-otel-tracing repo properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ based on [OpenTracing](https://github.com/opentracing/opentracing-cpp).
 Envoy Proxy versions 1.15 until 1.29 are supported by the distributed tracing based on OpenTracing.
 
 With Envoy version 1.30 onwards, tracing is based on [OpenTelemetry](https://opentelemetry.io/docs/languages/cpp/).
-There will be a demonstration repository [envoy-otel-tracing](https://github.com/instana/envoy-tracing) soon.
+Visit the demonstration repository [envoy-otel-tracing](https://github.com/instana/envoy-otel-tracing)
+for those.
 
 ## Prerequisites
 


### PR DESCRIPTION
There is a copy and paste issue in the repo link. It links to itself instead of to the new repo. Also the repo is now available. So refer to the real thing now.