### PR TITLE
README: Add 1.11.0 and 1.10.0 to release history

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ Only `linux-amd64-libcxx-libinstana_sensor.so` is required.
 
 ### 1.11.0 (2025-01-21)
 
-  * Add support for envoy-proxy 1.32.2 1.32.3 and 1.33.0
-  * Removed the agent header check for the `Server` header in the discovery response.
+  * The discovery response is not checked for the agent header `Server` anymore.
 
 ### 1.10.0 (2024-10-14)
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ Only `linux-amd64-libcxx-libinstana_sensor.so` is required.
 
 ## Release History
 
+### 1.11.0 (2025-01-21)
+
+  * Add support for envoy-proxy 1.32.2 1.32.3 and 1.33.0
+  * Removed the agent header check for the `Server` header in the discovery response.
+
+### 1.10.0 (2024-10-14)
+
+  * No changes regarding Envoy Proxy tracing
+
 ### 1.9.1 (2024-08-22)
 
   * No changes regarding Envoy Proxy tracing


### PR DESCRIPTION
### What
DOC: Announce the changes from cpp-sensor 1.11.0, significant for the end users.

  * Add support for envoy-proxy 1.32.2 1.32.3 and 1.33.0
  * Removed the agent header check for the `Server` header in the discovery response.


### Why
Compliance