### PR TITLE
envoy, server-app: Bump to Envoy 1.29-latest

### DIFF
--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -1,5 +1,5 @@
 # Original from envoyproject/envoy:examples/front-proxy/Dockerfile-frontenvoy
-FROM envoyproxy/envoy:v1.27-latest
+FROM envoyproxy/envoy:v1.29-latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -25,7 +25,7 @@ RUN access_key=$([ ! -z "${INSTANA_DOWNLOAD_KEY}" ] && echo "${INSTANA_DOWNLOAD_
 COPY . .
 RUN ./mvnw clean package
 
-FROM envoyproxy/envoy:v1.27-latest
+FROM envoyproxy/envoy:v1.29-latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \


### PR DESCRIPTION
The Envoy version is still at 1.27-latest. There is nothing more recent than 1.29.x because of the move to OTel with 1.30. So bump this to 1.29-latest.